### PR TITLE
Fix security, dead code, and API response consistency

### DIFF
--- a/src/app/map/page.js
+++ b/src/app/map/page.js
@@ -205,6 +205,7 @@ export default function SpacesMapPage() {
           activeTypes={activeTypes}
           autoFit
           fitKey={`split-${filteredSpaces.length}`}
+          initialAutoFitZoomOffset={1}
           focusSpaceId={focusedSpaceId}
           initialCenter={{ lat: 51.3397, lng: 12.3731 }}
           initialZoom={11}

--- a/src/components/MapComponent.js
+++ b/src/components/MapComponent.js
@@ -123,6 +123,7 @@ export default function MapComponent({
   fallbackToAllSpaces = true,
   fitPadding,
   maxAutoFitZoom = DEFAULT_MAX_AUTO_FIT_ZOOM,
+  initialAutoFitZoomOffset = 0,
   focusPadding,
 }) {
   const [mapData, setMapData] = useState([]);
@@ -130,6 +131,7 @@ export default function MapComponent({
   const mapRef = useRef(null);
   const markersRef = useRef([]);
   const focusMarkerRef = useRef(null);
+  const initialAutoFitOffsetAppliedRef = useRef(false);
 
   useEffect(() => {
     async function fetchData() {
@@ -386,11 +388,47 @@ export default function MapComponent({
     if (autoFit && hasValidBounds) {
       try {
         const padding = getViewportPadding(fitPadding, DEFAULT_FIT_PADDING);
-        mapRef.current.fitBounds(bounds, {
-          padding,
-          maxZoom: maxAutoFitZoom,
-          duration: 800,
-        });
+        const map = mapRef.current;
+        const shouldApplyInitialOffset =
+          typeof initialAutoFitZoomOffset === 'number' &&
+          initialAutoFitZoomOffset !== 0 &&
+          !initialAutoFitOffsetAppliedRef.current;
+
+        if (shouldApplyInitialOffset) {
+          const camera = map.cameraForBounds(bounds, {
+            padding,
+            maxZoom: maxAutoFitZoom,
+          });
+
+          if (camera && typeof camera.zoom === 'number') {
+            initialAutoFitOffsetAppliedRef.current = true;
+            const targetZoom = Math.min(
+              map.getMaxZoom(),
+              Math.max(
+                map.getMinZoom(),
+                camera.zoom + initialAutoFitZoomOffset
+              )
+            );
+            map.easeTo({
+              ...camera,
+              zoom: targetZoom,
+              duration: 800,
+              essential: true,
+            });
+          } else {
+            map.fitBounds(bounds, {
+              padding,
+              maxZoom: maxAutoFitZoom,
+              duration: 800,
+            });
+          }
+        } else {
+          map.fitBounds(bounds, {
+            padding,
+            maxZoom: maxAutoFitZoom,
+            duration: 800,
+          });
+        }
       } catch (err) {
         console.warn('Map fitBounds failed:', err);
       }


### PR DESCRIPTION
Title: Add initialAutoFitZoomOffset prop to MapComponent
Description: Adds a prop to control the initial zoom level offset when the map auto-fits to bounds, and sets it to +1 on the map page so the initial view zooms in one level closer.