### PR TITLE
Show Disconnect button in menu on mobile

### DIFF
--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -25,7 +25,7 @@ export default function Menu(props) {
   );
 }
 
-function MenuContent({ menuOpen, toggleMenu, theme, toggleTheme, themeLabel }) {
+function MenuContent({ menuOpen, toggleMenu, theme, toggleTheme, themeLabel, onSignOut }) {
   const {
     selectedFilters,
     setSelectedFilters,
@@ -357,6 +357,14 @@ function MenuContent({ menuOpen, toggleMenu, theme, toggleTheme, themeLabel }) {
                 );
               })}
             </div>
+            {user && (
+              <button
+                type='button'
+                onClick={onSignOut}
+                className='nav-action w-full justify-center sm:hidden'>
+                Disconnect
+              </button>
+            )}
           </div>
 
           <div className='space-y-3'>

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -234,6 +234,7 @@ function NavBarContent() {
         theme={theme}
         toggleTheme={toggleTheme}
         themeLabel={themeToggleLabel}
+        onSignOut={handleSignOut}
       />
     </>
   );


### PR DESCRIPTION
The navbar Disconnect button was hidden below sm breakpoint with no alternative. Passes onSignOut from NavBar into Menu and renders the button inside the Navigator section, visible only on mobile (sm:hidden) to avoid duplicating it alongside the navbar button on larger screens.