### PR TITLE
Fix map theme: switch basemap and overlay colors in dusk mode

### DIFF
--- a/src/app/map/page.js
+++ b/src/app/map/page.js
@@ -28,6 +28,7 @@ function prettifyType(t) {
 export default function SpacesMapPage() {
   const [spaces, setSpaces] = useState([]);
   const [activeTypes, setActiveTypes] = useState([]);
+  const [mapStyle, setMapStyle] = useState('mapbox://styles/mapbox/light-v11');
   const [searchQuery, setSearchQuery] = useState('');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
@@ -43,6 +44,19 @@ export default function SpacesMapPage() {
       .then((d) => { if (alive) { setSpaces(Array.isArray(d) ? d : []); setLoading(false); } })
       .catch((e) => { console.error(e); if (alive) { setError('Unable to load spaces.'); setLoading(false); } });
     return () => { alive = false; };
+  }, []);
+
+  useEffect(() => {
+    const getStyle = () =>
+      document.documentElement.classList.contains('dusk')
+        ? 'mapbox://styles/mapbox/dark-v11'
+        : 'mapbox://styles/mapbox/light-v11';
+
+    setMapStyle(getStyle());
+
+    const observer = new MutationObserver(() => setMapStyle(getStyle()));
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
+    return () => observer.disconnect();
   }, []);
 
   const typeFilters = useMemo(() => {
@@ -98,6 +112,17 @@ export default function SpacesMapPage() {
 
   const clearFilters = useCallback(() => { setSearchQuery(''); setActiveTypes([]); }, []);
   const hasFilters = activeTypes.length > 0 || !!searchQuery.trim();
+  const isDusk = mapStyle.includes('dark');
+
+  // Overlay styles adapt to map theme so text is always readable against the map background
+  const overlayBg = isDusk
+    ? 'bg-[#1e1e1e]/95 border-white/10'
+    : 'bg-white/90 border-black/8';
+  const overlayText = isDusk ? 'text-white/80' : 'text-black/60';
+  const overlayTextStrong = isDusk ? 'text-white' : 'text-black/85';
+  const inputClass = isDusk
+    ? 'bg-white/8 border-white/12 text-white placeholder:text-white/35 focus:ring-white/25'
+    : 'bg-black/5 border-black/10 text-black/80 placeholder:text-black/35 focus:ring-black/20';
 
   return (
     <div
@@ -114,6 +139,7 @@ export default function SpacesMapPage() {
         focusSpaceId={focusedSpaceId}
         initialCenter={INITIAL_CENTER}
         initialZoom={INITIAL_ZOOM}
+        mapStyle={mapStyle}
         minAutoFitZoom={5}
         onMarkerSelect={handleMarkerSelect}
         showPopups={false}
@@ -123,14 +149,14 @@ export default function SpacesMapPage() {
       <div className='pointer-events-none absolute inset-x-3 top-3 z-10 flex flex-col gap-2 sm:inset-x-4 sm:top-4'>
 
         {/* Stats + search row */}
-        <div className='pointer-events-auto rounded-2xl border border-[var(--foreground)]/12 bg-[var(--background)]/88 px-4 py-3 shadow-[0_8px_32px_rgba(0,0,0,0.12)] backdrop-blur-2xl'>
+        <div className={`pointer-events-auto rounded-2xl border px-4 py-3 shadow-[0_8px_32px_rgba(0,0,0,0.14)] backdrop-blur-2xl ${overlayBg}`}>
           <div className='flex items-center gap-3'>
             {cityStats.cities.length > 0 ? (
-              <p className='flex-1 truncate text-[10px] uppercase tracking-[0.24em] text-[var(--foreground)]/55'>
+              <p className={`flex-1 truncate text-[10px] uppercase tracking-[0.24em] ${overlayText}`}>
                 {cityStats.total} spaces · {cityStats.cities.join(' · ')}
               </p>
             ) : (
-              <p className='flex-1 text-[10px] uppercase tracking-[0.24em] text-[var(--foreground)]/40'>
+              <p className={`flex-1 text-[10px] uppercase tracking-[0.24em] ${overlayText}`}>
                 Spaces
               </p>
             )}
@@ -141,7 +167,7 @@ export default function SpacesMapPage() {
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
                 placeholder='Search…'
-                className='w-36 rounded-full border border-[var(--foreground)]/14 bg-[var(--background)]/70 px-3 py-1.5 text-[11px] tracking-wide text-[var(--foreground)] placeholder:text-[var(--foreground)]/35 focus:outline-none focus:ring-1 focus:ring-[var(--foreground)]/30 sm:w-48'
+                className={`w-36 rounded-full border px-3 py-1.5 text-[11px] tracking-wide focus:outline-none focus:ring-1 sm:w-48 ${inputClass}`}
                 aria-label='Search spaces'
               />
               {searchQuery && (
@@ -149,7 +175,7 @@ export default function SpacesMapPage() {
                   type='button'
                   onClick={() => setSearchQuery('')}
                   aria-label='Clear search'
-                  className='text-[var(--foreground)]/40 hover:text-[var(--foreground)]'>
+                  className={overlayText}>
                   <svg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='currentColor' strokeWidth='2.5'>
                     <path d='M18 6 6 18M6 6l12 12'/>
                   </svg>
@@ -171,8 +197,12 @@ export default function SpacesMapPage() {
                   onClick={() => toggleType(type)}
                   className={`flex items-center gap-1.5 rounded-full border px-3 py-1 text-[10px] uppercase tracking-[0.28em] shadow-sm backdrop-blur-xl transition ${
                     active
-                      ? 'border-[var(--foreground)] bg-[var(--foreground)] text-[var(--background)]'
-                      : 'border-[var(--foreground)]/15 bg-[var(--background)]/80 text-[var(--foreground)]/70 hover:border-[var(--foreground)]/35'
+                      ? isDusk
+                        ? 'border-white bg-white text-black'
+                        : 'border-black/80 bg-black/85 text-white'
+                      : isDusk
+                        ? 'border-white/20 bg-[#1e1e1e]/90 text-white/75 hover:border-white/40'
+                        : 'border-black/12 bg-white/88 text-black/65 hover:border-black/28'
                   }`}>
                   <span
                     className='h-2 w-2 rounded-full'
@@ -187,7 +217,11 @@ export default function SpacesMapPage() {
               <button
                 type='button'
                 onClick={clearFilters}
-                className='rounded-full border border-[var(--foreground)]/15 bg-[var(--background)]/80 px-3 py-1 text-[10px] uppercase tracking-[0.28em] text-[var(--foreground)]/50 shadow-sm backdrop-blur-xl hover:text-[var(--foreground)]'>
+                className={`rounded-full border px-3 py-1 text-[10px] uppercase tracking-[0.28em] shadow-sm backdrop-blur-xl transition ${
+                  isDusk
+                    ? 'border-white/20 bg-[#1e1e1e]/90 text-white/50 hover:text-white'
+                    : 'border-black/12 bg-white/88 text-black/45 hover:text-black/80'
+                }`}>
                 Clear
               </button>
             )}
@@ -198,15 +232,15 @@ export default function SpacesMapPage() {
       {/* ── Selected space card ────────────────────────────────── */}
       {cardOpen && focusedSpace && (
         <div className='pointer-events-none absolute inset-x-3 bottom-20 z-20 flex justify-center sm:inset-x-4 lg:inset-auto lg:bottom-6 lg:right-5 lg:justify-end'>
-          <div className='pointer-events-auto w-full max-w-sm overflow-hidden rounded-[22px] border border-[var(--foreground)]/10 bg-[var(--background)]/95 shadow-[0_20px_60px_rgba(0,0,0,0.22)] backdrop-blur-2xl'>
-            <div className='flex items-center justify-between border-b border-[var(--foreground)]/8 px-5 py-3'>
-              <span className='text-[10px] uppercase tracking-[0.32em] text-[var(--foreground)]/45'>
+          <div className={`pointer-events-auto w-full max-w-sm overflow-hidden rounded-[22px] border shadow-[0_20px_60px_rgba(0,0,0,0.28)] backdrop-blur-2xl ${overlayBg}`}>
+            <div className={`flex items-center justify-between border-b px-5 py-3 ${isDusk ? 'border-white/8' : 'border-black/6'}`}>
+              <span className={`text-[10px] uppercase tracking-[0.32em] ${overlayText}`}>
                 Space
               </span>
               <button
                 type='button'
                 onClick={() => setCardOpen(false)}
-                className='text-[10px] uppercase tracking-[0.28em] text-[var(--foreground)]/45 transition hover:text-[var(--foreground)]'>
+                className={`text-[10px] uppercase tracking-[0.28em] transition ${overlayText} hover:${overlayTextStrong}`}>
                 Close
               </button>
             </div>
@@ -229,7 +263,11 @@ export default function SpacesMapPage() {
           <button
             type='button'
             onClick={() => setSheetOpen(true)}
-            className='flex items-center gap-2 rounded-full border border-[var(--foreground)]/15 bg-[var(--background)]/90 px-6 py-2.5 text-[11px] uppercase tracking-[0.32em] text-[var(--foreground)]/75 shadow-[0_8px_32px_rgba(0,0,0,0.16)] backdrop-blur-xl transition hover:text-[var(--foreground)]'>
+            className={`flex items-center gap-2 rounded-full border px-6 py-2.5 text-[11px] uppercase tracking-[0.32em] shadow-[0_8px_32px_rgba(0,0,0,0.18)] backdrop-blur-xl transition ${
+              isDusk
+                ? 'border-white/18 bg-[#1e1e1e]/92 text-white/70 hover:text-white'
+                : 'border-black/12 bg-white/90 text-black/60 hover:text-black/90'
+            }`}>
             <svg xmlns='http://www.w3.org/2000/svg' width='13' height='13' viewBox='0 0 24 24' fill='none' stroke='currentColor' strokeWidth='2' aria-hidden='true'>
               <line x1='8' y1='6' x2='21' y2='6'/><line x1='8' y1='12' x2='21' y2='12'/><line x1='8' y1='18' x2='21' y2='18'/>
               <line x1='3' y1='6' x2='3.01' y2='6'/><line x1='3' y1='12' x2='3.01' y2='12'/><line x1='3' y1='18' x2='3.01' y2='18'/>

--- a/src/components/MapComponent.js
+++ b/src/components/MapComponent.js
@@ -115,6 +115,7 @@ export default function MapComponent({
   activeTypes,
   initialCenter,
   initialZoom,
+  mapStyle = 'mapbox://styles/mapbox/light-v11',
   autoFit = false,
   fitKey,
   focusSpaceId,
@@ -191,7 +192,7 @@ export default function MapComponent({
 
     const map = new mapboxgl.Map({
       container: mapContainerRef.current,
-      style: 'mapbox://styles/mapbox/light-v11',
+      style: mapStyle,
       center: [centerLng, centerLat],
       zoom: finalZoom,
     });
@@ -199,11 +200,17 @@ export default function MapComponent({
     map.addControl(new mapboxgl.NavigationControl(), 'top-right');
 
     mapRef.current = map;
-    return () => map.remove();
+    return () => {
+      clearMarkers();
+      map.remove();
+      mapRef.current = null;
+    };
   // initialCenter, initialZoom, spaces are initial values — re-running this
   // effect when they change would destroy and recreate the map unnecessarily.
+  // mapStyle IS reactive: when the user toggles dawn/dusk the map reinitialises
+  // with the correct basemap style.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mapData, eventId]);
+  }, [mapData, eventId, mapStyle]);
 
   const updateMarkerFocusStyles = (currentFocusId) => {
     markersRef.current.forEach(({ element, id }) => {
@@ -443,7 +450,7 @@ export default function MapComponent({
     if (mapData.length > 0 && mapRef.current) {
       addMarkers();
     }
-  }, [mapData, activeTypes, eventId, fallbackAddress, autoFit, fitKey, onMarkerSelect, showPopups]);
+  }, [mapData, activeTypes, eventId, fallbackAddress, autoFit, fitKey, onMarkerSelect, showPopups, mapStyle]);
 
   useEffect(() => {
     if (!autoFit || !mapRef.current) return;


### PR DESCRIPTION
In dusk mode the map was always light-v11 (grey/white), making the dark-themed overlay controls hard to read against the light background.

- Detect dawn/dusk class on <html> with MutationObserver; pass the matching Mapbox style (light-v11 / dark-v11) to MapComponent
- MapComponent reinitialises the map (and re-adds markers) whenever mapStyle changes, so toggling the theme live works correctly
- Floating overlays (stats bar, search, filter pills, space card, list button) now use explicit dark/light colors based on isDusk instead of CSS variables, so they always contrast correctly against the map